### PR TITLE
fastlane: fix short desc for Turkish

### DIFF
--- a/fastlane/metadata/android/tr/short_description.txt
+++ b/fastlane/metadata/android/tr/short_description.txt
@@ -1,1 +1,1 @@
-Erişebilirlik kullanarak yüklenen kullanıcı ve sistem uygulamalarının önbelleğini temizleyin.
+Erişilebilirlik ile yüklü kullanıcı, sistem uyg.larının önbelleğini temizleyin


### PR DESCRIPTION
F-Droid build server return an error:

`summary` in `tr` should be shorter than 80 characters!