### PR TITLE
build: disable dependenciesInfo metadata for F-Droid

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,13 @@ kotlin {
             }
         }
 
+        dependenciesInfo {
+            // Disables dependency metadata when building APKs.
+            includeInApk = false
+            // Disables dependency metadata when building Android App bundles.
+            includeInBundle = false
+        }
+
         signingConfigs {
             create("release") {
                 keyAlias = "AppCacheCleaner"


### PR DESCRIPTION
Set dependenciesInfo.includeInApk = false and includeInBundle = false so the signed dependency-metadata block is omitted from release artifacts. That block is non-reproducible and unverifiable, which fails F-Droid's reproducible-build requirement; F-Droid also rejects the Google-signed metadata. No effect on app behavior.